### PR TITLE
fix(build): compile whole project in ext script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "ext": "tsc src/extension.ts --outdir build --skipLibCheck --module commonjs",
+    "ext": "tsc --outdir build --skipLibCheck --module commonjs",
     "compile": "npm run build && npm run ext",
     "serve": "vite preview"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "ext": "tsc --outdir build --skipLibCheck --module commonjs",
+    "ext": "tsc --outdir build --skipLibCheck --module commonjs --noEmit false",
     "compile": "npm run build && npm run ext",
     "serve": "vite preview"
   },


### PR DESCRIPTION
Hi, thank you for this boilerplate--it's just what I was looking for.  

In my project, I have some global declarations in `.d.ts` files.  Since these are picked up by the compiler, and _not_ imported directly from any module, they will be missed by `tsc` if we only compile `src/extension.ts`.  If we compile the whole thing, then those definitions will be found and compilation will succeed.

I figured this was a pretty harmless change and may help someone else, so I'm sending it over.  Do with it what you will!
